### PR TITLE
fix: ensure toast notifications always appear at bottom-center

### DIFF
--- a/frontend/src/app.module.ts
+++ b/frontend/src/app.module.ts
@@ -14,7 +14,10 @@ import { MatSelectModule } from "@angular/material/select";
 import { MatInputModule } from "@angular/material/input";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatTabsModule } from "@angular/material/tabs";
-import { MatSnackBarModule } from "@angular/material/snack-bar";
+import {
+  MatSnackBarModule,
+  MAT_SNACK_BAR_DEFAULT_OPTIONS,
+} from "@angular/material/snack-bar";
 
 import { MatChipsModule } from "@angular/material/chips";
 import { MatTooltipModule } from "@angular/material/tooltip";
@@ -55,7 +58,17 @@ import { TranscriptionService } from "./services/transcription.service";
     HistoryComponent,
     ModelSelectorComponent,
   ],
-  providers: [ElectronService, TranscriptionService],
+  providers: [
+    ElectronService,
+    TranscriptionService,
+    {
+      provide: MAT_SNACK_BAR_DEFAULT_OPTIONS,
+      useValue: {
+        horizontalPosition: "center",
+        verticalPosition: "bottom",
+      },
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/frontend/src/components/transcription/transcription.component.ts
+++ b/frontend/src/components/transcription/transcription.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from "@angular/core";
+import { Component, OnInit, OnDestroy, NgZone } from "@angular/core";
 import { ElectronService } from "../../services/electron.service";
 import { TranscriptionService } from "../../services/transcription.service";
 import { MatSnackBar } from "@angular/material/snack-bar";
@@ -49,6 +49,7 @@ export class TranscriptionComponent implements OnInit, OnDestroy {
     private electronService: ElectronService,
     private transcriptionService: TranscriptionService,
     private snackBar: MatSnackBar,
+    private ngZone: NgZone,
   ) {}
 
   ngOnInit() {
@@ -63,20 +64,24 @@ export class TranscriptionComponent implements OnInit, OnDestroy {
 
       // Listen for transcription completion
       (window as any).electronAPI?.onTranscriptionCompleted?.((result: any) => {
-        this.transcriptionResult = result;
-        this.isTranscribing = false;
-        this.transcriptionProgress = 100;
-        this.snackBar.open("Transcription completed!", "Close", {
-          duration: 3000,
+        this.ngZone.run(() => {
+          this.transcriptionResult = result;
+          this.isTranscribing = false;
+          this.transcriptionProgress = 100;
+          this.snackBar.open("Transcription completed!", "Close", {
+            duration: 3000,
+          });
         });
       });
 
       // Listen for transcription errors
       (window as any).electronAPI?.onTranscriptionError?.((error: string) => {
-        this.isTranscribing = false;
-        this.transcriptionProgress = 0;
-        this.snackBar.open(error || "Transcription failed", "Close", {
-          duration: 5000,
+        this.ngZone.run(() => {
+          this.isTranscribing = false;
+          this.transcriptionProgress = 0;
+          this.snackBar.open(error || "Transcription failed", "Close", {
+            duration: 5000,
+          });
         });
       });
 


### PR DESCRIPTION
## Summary
This PR fixes the issue where toast notifications appear at the top-left of the UI and then move to the bottom-center when transcription completes.

## Changes
- Added global MatSnackBar configuration in 
- Set default  to 'center' and  to 'bottom'
- This ensures all toast notifications consistently appear at the bottom-center from the start

## Issue
Fixes #3

## Testing
All toast notifications throughout the app will now:
- Appear at bottom-center immediately (no position jumping)
- Provide consistent user experience
- Prevent confusion about app state

## Impact
This change affects all snackbar/toast notifications in the application:
- File selection notifications
- Transcription completion/error messages
- Copy to clipboard confirmations
- Model download notifications
- Save transcript confirmations